### PR TITLE
Add partial support for SVG 2

### DIFF
--- a/svglab/attrs/common.py
+++ b/svglab/attrs/common.py
@@ -72,5 +72,17 @@ class FontVariant(Attr):
     ] = None
 
 
+class FontSize(Attr):
+    font_size: models.Attr[
+        typedefs.AbsoluteSize
+        | typedefs.RelativeSize
+        | typedefs.Length
+        | typedefs.Percentage
+        | typedefs.Inherit
+        | typedefs.All
+        | typedefs.ListOfLengths
+    ] = None
+
+
 class Fill(Attr):
     fill: models.Attr[typedefs.Paint | Literal["freeze", "remove"]] = None

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -60,6 +60,7 @@ class Presentation(
     presentation.TextDecoration,
     presentation.TextRendering,
     presentation.UnicodeBidi,
+    presentation.VectorEffect,
     presentation.Visibility,
     presentation.WordSpacing,
     presentation.WritingMode,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -58,6 +58,7 @@ class Presentation(
     presentation.StrokeWidth,
     presentation.TextAlign,
     presentation.TextAlignAll,
+    presentation.TextAlignLast,
     presentation.TextAnchor,
     presentation.TextDecoration,
     presentation.TextRendering,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -62,6 +62,7 @@ class Presentation(
     presentation.Visibility,
     presentation.WordSpacing,
     presentation.WritingMode,
+    presentation.ZIndex,
 ):
     pass
 

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -43,6 +43,7 @@ class Presentation(
     presentation.Mask,
     presentation.Opacity,
     presentation.Overflow,
+    presentation.PaintOrder,
     presentation.PointerEvents,
     presentation.ShapeRendering,
     presentation.StopColor,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -56,6 +56,7 @@ class Presentation(
     presentation.StrokeMiterlimit,
     presentation.StrokeOpacity,
     presentation.StrokeWidth,
+    presentation.TextAlign,
     presentation.TextAnchor,
     presentation.TextDecoration,
     presentation.TextRendering,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -59,6 +59,7 @@ class Presentation(
     presentation.TextAnchor,
     presentation.TextDecoration,
     presentation.TextRendering,
+    presentation.TransformBox,
     presentation.TransformOrigin,
     presentation.UnicodeBidi,
     presentation.VectorEffect,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -59,6 +59,7 @@ class Presentation(
     presentation.TextAnchor,
     presentation.TextDecoration,
     presentation.TextRendering,
+    presentation.TransformOrigin,
     presentation.UnicodeBidi,
     presentation.VectorEffect,
     presentation.Visibility,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -13,6 +13,7 @@ class Core(
 
 class Presentation(
     common.Fill,
+    common.FontSize,
     common.FontStretch,
     common.FontStyle,
     common.FontVariant,
@@ -30,7 +31,6 @@ class Presentation(
     presentation.DominantBaseline,
     presentation.FillOpacity,
     presentation.FillRule,
-    presentation.FontSize,
     presentation.FontSizeAdjust,
     presentation.GlyphOrientationHorizontal,
     presentation.GlyphOrientationVertical,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -61,6 +61,7 @@ class Presentation(
     presentation.TextAlignLast,
     presentation.TextAnchor,
     presentation.TextDecoration,
+    presentation.TextIndent,
     presentation.TextRendering,
     presentation.TransformBox,
     presentation.TransformOrigin,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -57,6 +57,7 @@ class Presentation(
     presentation.StrokeOpacity,
     presentation.StrokeWidth,
     presentation.TextAlign,
+    presentation.TextAlignAll,
     presentation.TextAnchor,
     presentation.TextDecoration,
     presentation.TextRendering,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -68,6 +68,7 @@ class Presentation(
     presentation.UnicodeBidi,
     presentation.VectorEffect,
     presentation.Visibility,
+    presentation.WhiteSpace,
     presentation.WordSpacing,
     presentation.WritingMode,
     presentation.ZIndex,

--- a/svglab/attrs/groups.py
+++ b/svglab/attrs/groups.py
@@ -1,7 +1,13 @@
 from svglab.attrs import common, presentation, regular
 
 
-class Core(regular.Id, regular.XmlBase, regular.XmlLang, regular.XmlSpace):
+class Core(
+    regular.Id,
+    regular.Lang,
+    regular.XmlBase,
+    regular.XmlLang,
+    regular.XmlSpace,
+):
     pass
 
 
@@ -151,6 +157,7 @@ class FilterPrimitives(
 
 
 class Xlink(
+    regular.Href,
     regular.XlinkActuateOnLoad,
     regular.XlinkArcrole,
     regular.XlinkHref,

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -419,6 +419,15 @@ class TextDecoration(common.Attr):
     ] = None
 
 
+class TextIndent(common.Attr):
+    text_indent: models.Attr[
+        typedefs.Length
+        | typedefs.Percentage
+        | Literal["each-line", "hanging"]
+        | typedefs.Inherit
+    ] = None
+
+
 class TextRendering(common.Attr):
     text_rendering: models.Attr[
         typedefs.Auto

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -276,6 +276,13 @@ class Overflow(common.Attr):
     ] = None
 
 
+class PaintOrder(common.Attr):
+    paint_order: (
+        models.Attr[Literal["normal", "fill", "stroke", "markers"]]
+        | typedefs.Inherit
+    ) = None
+
+
 class PointerEvents(common.Attr):
     pointer_events: models.Attr[
         Literal[

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -480,6 +480,20 @@ class Visibility(common.Attr):
     ] = None
 
 
+class WhiteSpace(common.Attr):
+    white_space: models.Attr[
+        Literal[
+            "normal",
+            "pre",
+            "nowrap",
+            "pre-wrap",
+            "break-spaces",
+            "pre-line",
+        ]
+        | typedefs.Inherit
+    ] = None
+
+
 class WordSpacing(common.Attr):
     word_spacing: models.Attr[
         Literal["normal"] | typedefs.Length | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -332,7 +332,8 @@ class StrokeLinecap(common.Attr):
 
 class StrokeLinejoin(common.Attr):
     stroke_linejoin: models.Attr[
-        Literal["miter", "round", "bevel"] | typedefs.Inherit
+        Literal["miter", "round", "bevel", "miter-clip", "arcs"]
+        | typedefs.Inherit
     ] = None
 
 

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -189,16 +189,6 @@ class FontSizeAdjust(common.Attr):
     ] = None
 
 
-class FontSize(common.Attr):
-    font_size: models.Attr[
-        typedefs.AbsoluteSize
-        | typedefs.RelativeSize
-        | typedefs.Length
-        | typedefs.Percentage
-        | typedefs.Inherit
-    ] = None
-
-
 class GlyphOrientationHorizontal(common.Attr):
     glyph_orientation_horizontal: models.Attr[
         typedefs.Angle | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -382,6 +382,18 @@ class TextRendering(common.Attr):
     ] = None
 
 
+class TransformBox(common.Attr):
+    transform_box: models.Attr[
+        Literal[
+            "content-box",
+            "border-box",
+            "fill-box",
+            "stroke-box",
+            "view-box",
+        ]
+    ] = None
+
+
 class TransformOrigin(common.Attr):
     transform_origin: models.Attr[
         typedefs.TransformOrigin | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -398,6 +398,18 @@ class UnicodeBidi(common.Attr):
     ] = None
 
 
+class VectorEffect(common.Attr):
+    vector_effect: models.Attr[
+        Literal[
+            "non-scaling-stroke",
+            "non-scaling-size",
+            "non-rotation",
+            "fixed-position",
+        ]
+        | typedefs.None_
+    ] = None
+
+
 class Visibility(common.Attr):
     visibility: models.Attr[
         Literal["visible", "hidden", "collapse"] | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -374,6 +374,21 @@ class TextAlign(common.Attr):
     ] = None
 
 
+class TextAlignAll(common.Attr):
+    text_align_all: models.Attr[
+        Literal[
+            "start",
+            "end",
+            "left",
+            "right",
+            "center",
+            "justify",
+            "match-parent",
+        ]
+        | typedefs.Inherit
+    ] = None
+
+
 class TextAnchor(common.Attr):
     text_anchor: models.Attr[
         Literal["start", "middle", "end"] | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -382,6 +382,12 @@ class TextRendering(common.Attr):
     ] = None
 
 
+class TransformOrigin(common.Attr):
+    transform_origin: models.Attr[
+        typedefs.TransformOrigin | typedefs.Inherit
+    ] = None
+
+
 class UnicodeBidi(common.Attr):
     unicode_bidi: models.Attr[
         Literal["normal", "embed", "bidi-override"] | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -389,6 +389,22 @@ class TextAlignAll(common.Attr):
     ] = None
 
 
+class TextAlignLast(common.Attr):
+    text_align_last: models.Attr[
+        typedefs.Auto
+        | Literal[
+            "start",
+            "end",
+            "left",
+            "right",
+            "center",
+            "justify",
+            "match-parent",
+        ]
+        | typedefs.Inherit
+    ] = None
+
+
 class TextAnchor(common.Attr):
     text_anchor: models.Attr[
         Literal["start", "middle", "end"] | typedefs.Inherit

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -408,3 +408,9 @@ class WritingMode(common.Attr):
         Literal["lr-tb", "rl-tb", "tb-rl", "lr", "rl", "tb"]
         | typedefs.Inherit
     ] = None
+
+
+class ZIndex(common.Attr):
+    z_index: models.Attr[
+        typedefs.Integer | typedefs.Auto | typedefs.Inherit
+    ] = None

--- a/svglab/attrs/presentation.py
+++ b/svglab/attrs/presentation.py
@@ -358,6 +358,22 @@ class Stroke(common.Attr):
     stroke: models.Attr[typedefs.Paint] = None
 
 
+class TextAlign(common.Attr):
+    text_align: models.Attr[
+        Literal[
+            "start",
+            "end",
+            "left",
+            "right",
+            "center",
+            "justify",
+            "match-parent",
+            "justify-all",
+        ]
+        | typedefs.Inherit
+    ] = None
+
+
 class TextAnchor(common.Attr):
     text_anchor: models.Attr[
         Literal["start", "middle", "end"] | typedefs.Inherit

--- a/svglab/attrs/regular.py
+++ b/svglab/attrs/regular.py
@@ -196,6 +196,10 @@ class Format(common.Attr):
     format: models.Attr[typedefs.Unparsed] = None
 
 
+class Fr(common.Attr):
+    fr: models.Attr[typedefs.Length] = None
+
+
 class From(common.Attr):
     from_: models.Attr[typedefs.Unparsed] = None
 

--- a/svglab/attrs/regular.py
+++ b/svglab/attrs/regular.py
@@ -258,6 +258,10 @@ class HorizOriginY(common.Attr):
     horiz_origin_y: models.Attr[typedefs.Number] = None
 
 
+class Href(common.Attr):
+    href: models.Attr[typedefs.Url] = None
+
+
 class Id(common.Attr):
     id: models.Attr[typedefs.Name] = None
 
@@ -327,6 +331,10 @@ class KeyTimes(common.Attr):
 
 
 class Lang(common.Attr):
+    lang: models.Attr[typedefs.LanguageTag] = None
+
+
+class LangGlyph(common.Attr):
     lang: models.Attr[typedefs.LanguageCodes] = None
 
 

--- a/svglab/attrs/regular.py
+++ b/svglab/attrs/regular.py
@@ -192,10 +192,6 @@ class FontFamily(common.Attr):
     ] = None
 
 
-class FontSize(common.Attr):
-    font_size: models.Attr[typedefs.All | typedefs.ListOfLengths] = None
-
-
 class Format(common.Attr):
     format: models.Attr[typedefs.Unparsed] = None
 

--- a/svglab/attrs/typedefs.py
+++ b/svglab/attrs/typedefs.py
@@ -33,7 +33,6 @@ ListOfCoordinates: TypeAlias = Unparsed
 ListOfLengths: TypeAlias = Unparsed
 MediaDescriptors: TypeAlias = Unparsed
 Name: TypeAlias = Unparsed
-Percentage: TypeAlias = Unparsed
 ProfileName: TypeAlias = Unparsed
 Shape: TypeAlias = Unparsed
 Urange: TypeAlias = Unparsed
@@ -111,3 +110,4 @@ Paint: TypeAlias = (
     # <funciri> [ none | currentColor | <color> [<icccolor>] ]
     | Unparsed
 )
+Percentage: TypeAlias = Length

--- a/svglab/attrs/typedefs.py
+++ b/svglab/attrs/typedefs.py
@@ -28,6 +28,7 @@ GenericFamily: TypeAlias = Unparsed
 Iri: TypeAlias = Unparsed
 LanguageCodes: TypeAlias = Unparsed
 LanguageId: TypeAlias = Unparsed
+LanguageTag: TypeAlias = Unparsed
 ListOfCoordinates: TypeAlias = Unparsed
 ListOfLengths: TypeAlias = Unparsed
 MediaDescriptors: TypeAlias = Unparsed
@@ -62,6 +63,8 @@ Number: TypeAlias = float
 PathData: TypeAlias = attrparse.DType
 RelativeSize: TypeAlias = Literal["smaller", "larger"]
 TransformList: TypeAlias = attrparse.TransformType
+Url: TypeAlias = pydantic.AnyUrl
+
 
 # composite types
 Coordinate: TypeAlias = Length

--- a/svglab/attrs/typedefs.py
+++ b/svglab/attrs/typedefs.py
@@ -111,3 +111,15 @@ Paint: TypeAlias = (
     | Unparsed
 )
 Percentage: TypeAlias = Length
+
+_TransformOriginDirection: TypeAlias = Literal[
+    "left", "center", "right", "top", "bottom"
+]
+_TransformOriginValue: TypeAlias = (
+    _TransformOriginDirection | Percentage | Length
+)
+TransformOrigin: TypeAlias = (
+    _TransformOriginValue
+    | models.Tuple2[_TransformOriginValue, _TransformOriginValue]
+    | models.Tuple3[_TransformOriginValue, _TransformOriginValue, Length]
+)

--- a/svglab/attrs/typedefs.py
+++ b/svglab/attrs/typedefs.py
@@ -104,7 +104,7 @@ OpacityValue: TypeAlias = Annotated[
 ]
 Paint: TypeAlias = (
     None_
-    | Literal["currentColor"]
+    | Literal["currentColor", "context-fill", "context-stroke"]
     | Inherit
     | Color
     # <funciri> [ none | currentColor | <color> [<icccolor>] ]

--- a/svglab/elements/tags.py
+++ b/svglab/elements/tags.py
@@ -764,7 +764,6 @@ class Path(
     regular.Class,
     regular.D,
     regular.ExternalResourcesRequired,
-    regular.PathLength,
     regular.Style,
     regular.Transform,
     traits.Shape,

--- a/svglab/elements/tags.py
+++ b/svglab/elements/tags.py
@@ -602,7 +602,7 @@ class Glyph(
     regular.D,
     regular.GlyphName,
     regular.HorizAdvX,
-    regular.Lang,
+    regular.LangGlyph,
     regular.Orientation,
     regular.Style,
     regular.Unicode,

--- a/svglab/elements/tags.py
+++ b/svglab/elements/tags.py
@@ -519,7 +519,6 @@ class FontFace(
     regular.CapHeight,
     regular.Descent,
     regular.FontFamily,
-    regular.FontSize,
     regular.Hanging,
     regular.Ideographic,
     regular.Mathematical,

--- a/svglab/elements/tags.py
+++ b/svglab/elements/tags.py
@@ -827,6 +827,7 @@ class RadialGradient(
     regular.Cx,
     regular.Cy,
     regular.ExternalResourcesRequired,
+    regular.Fr,
     regular.Fx,
     regular.Fy,
     regular.GradientTransform,

--- a/svglab/elements/traits.py
+++ b/svglab/elements/traits.py
@@ -1,4 +1,4 @@
-from svglab.attrs import groups
+from svglab.attrs import groups, regular
 from svglab.elements import common
 
 
@@ -17,7 +17,7 @@ class Shape(GraphicsElement):
     pass
 
 
-class BasicShape(Shape):
+class BasicShape(regular.PathLength, Shape):
     pass
 
 


### PR DESCRIPTION
## New attributes

### Regular attributes

- `lang` (alternative to `xml:lang`)
- `href`(alternative to `xlink:href`)
- `fr` (for `radialGradient`)

### Presentation attributes

- `z-index`
- `paint-order`
- `vector-offset`
- `transform-origin`
- `transform-box`
- `text-align`
- `text-align-all`
- `text-align-last`
- `text-indent`
- `white-space`

## Changed attributes

- `stroke-linejoin` now includes options `miter-clip` and `arcs`


## Other changes

- `<paint>` now includes options `context-fill` and `context-stroke`
- `<percentage>` is now parsed into a `Length` (it was previously unparsed)
- `pathLength` now applies to all basic shapes

## References

- https://github.com/w3c/svgwg/wiki/SVG-2-new-features
- https://www.w3.org/TR/SVG2/