### PR TITLE
Add support for decomposing transformation matrices into elementary transformations

### DIFF
--- a/svglab/attrparse/transform.py
+++ b/svglab/attrparse/transform.py
@@ -436,7 +436,6 @@ class Matrix(_TransformFunctionBase):
 
             s = _magnitude((c, d))
             angle = 90 - utils.signum(d) * utils.arccos(-c / s)
-
             result.append(Rotate(angle))
 
             det = self.determinant()

--- a/svglab/attrparse/transform.py
+++ b/svglab/attrparse/transform.py
@@ -474,6 +474,33 @@ class Matrix(_TransformFunctionBase):
         return result
 
     def decompose(self) -> Transform:
+        """Decompose the matrix into elementary transformations.
+
+        The result is a list of transformations that, when composed, are
+        equivalent to the original matrix.
+
+        The algorithm is based on Frédéric Wang's [Decomposition of
+        2D-transform matrices](https://frederic-wang.fr/2013/12/01/decomposition-of-2d-transform-matrices/).
+
+        Two decomposition methods are used: QR and LDU. The
+        final decomposition is chosen based on which method produces the
+        transformation with the lowest complexity.
+
+        Returns:
+            A transformation list composed of elementary transformations.
+
+        Examples:
+        >>> m = Translate(10, 20).to_matrix()
+        >>> m.decompose()
+        [Translate(tx=10.0, ty=20.0)]
+        >>> m = SkewY(45).to_matrix()
+        >>> m.decompose()
+        [SkewY(angle=45.0)]
+        >>> m = Translate(10, 20) @ Scale(2, 2)
+        >>> m.decompose()
+        [Translate(tx=10.0, ty=20.0), Scale(sx=2.0, sy=2.0)]
+
+        """
         if self == Matrix.identity():
             return []
 

--- a/svglab/attrparse/transform.py
+++ b/svglab/attrparse/transform.py
@@ -249,7 +249,7 @@ class SkewX(_TransformFunctionBase):
         return utils.is_close(self.angle, other.angle)
 
 
-def _transform_weight(transform: Iterable[TransformFunction], /) -> float:
+def _transform_weight(transform: Iterable[TransformFunction], /) -> int:
     """Calculate the weight of a transformation.
 
     The weight is used to determine the best decomposition of a matrix.
@@ -266,14 +266,14 @@ def _transform_weight(transform: Iterable[TransformFunction], /) -> float:
 
     for t in transform:
         match t:
-            case Scale(sx, sy) if not utils.is_close(sx, sy):
-                weight += 1e3
-            case Rotate():
-                weight += 1e2
             case SkewX() | SkewY():
-                weight += 1e3
+                weight += 1_000_000
+            case Scale(sx, sy) if not utils.is_close(sx, sy):
+                weight += 1_000_000
+            case Rotate():
+                weight += 1_000
             case _:
-                weight += 1e1
+                weight += 1
 
     return weight
 

--- a/svglab/elements/traits.py
+++ b/svglab/elements/traits.py
@@ -111,7 +111,6 @@ def swap_transforms(
                 return b, a
 
             angle = utils.arctan(sx / sy * utils.tan(angle))
-
             return scale, type(a)(angle)
         case _:
             raise errors.SvgTransformSwapError(a, b)
@@ -471,6 +470,8 @@ class SupportsTransform(Element, regular.Transform):
 
         if not self.transform:
             return
+
+        transform.decompose_matrices(self.transform)
 
         reified = 0
         i = 0

--- a/svglab/utils.py
+++ b/svglab/utils.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Generator, Iterable, Sequence, Sized
 import bs4
 import typeguard
 from typing_extensions import (
+    Literal,
     SupportsFloat,
     SupportsIndex,
     TypeAlias,
@@ -482,3 +483,91 @@ def arctan(value: float) -> float:
             return -45
         case _:
             return math.degrees(math.atan(value))
+
+
+def degrees(radians: float) -> float:
+    """Convert radians to degrees, returning a value in the range (-180, 180].
+
+    Args:
+        radians: The angle in radians.
+
+    Returns:
+        The angle in degrees in the range (-180, 180].
+
+    Examples:
+        >>> from math import pi
+        >>> degrees(0)
+        0.0
+        >>> degrees(pi)
+        180.0
+        >>> degrees(2 * pi)
+        0.0
+        >>> degrees(-pi / 2)
+        -90.0
+        >>> degrees(-pi)
+        180.0
+
+    """
+    deg = math.degrees(radians)
+    normalized = ((deg + 180) % 360) - 180
+
+    if is_close(normalized, -180):
+        return 180.0
+
+    return normalized
+
+
+def signum(x: float) -> Literal[-1, 0, 1]:
+    """Compute the signum function `sgn(x)`.
+
+    Args:
+        x: The value to compute the signum of.
+
+    Returns:
+        -1 if the value is negative, 0 if the value is zero, and 1 if the value
+        is positive.
+
+    Examples:
+        >>> signum(-5)
+        -1
+        >>> signum(0)
+        0
+        >>> signum(0.5)
+        1
+
+    """
+    if x < 0:
+        return -1
+
+    if x > 0:
+        return 1
+
+    return 0
+
+
+def arccos(value: float) -> float:
+    """Compute the arccosine of a value in degrees.
+
+    This function is a wrapper around `math.acos` that returns "nice" values
+    for common inputs. The output is in degrees.
+
+    Args:
+        value: The value to compute the arccosine of.
+
+    Returns:
+        The arccosine of the value in degrees.
+
+    Examples:
+        >>> arccos(1)
+        0
+        >>> arccos(0)
+        90
+
+    """
+    match value:
+        case 1:
+            return 0
+        case 0:
+            return 90
+        case _:
+            return math.degrees(math.acos(value))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -767,6 +767,30 @@ def test_set_viewbox_sets_viewbox_attr() -> None:
                 reason="Transform/viewBox bug in resvg"
             ),
         ),
+        svglab.Svg(
+            width=svglab.Length(1000), height=svglab.Length(1000)
+        ).add_child(
+            svglab.Rect(
+                x=svglab.Length(200),
+                y=svglab.Length(200),
+                width=svglab.Length(100),
+                height=svglab.Length(100),
+                fill="red",
+                stroke="blue",
+                transform=[
+                    svglab.compose(
+                        [
+                            svglab.Translate(10, 20),
+                            svglab.Scale(2),
+                            svglab.Rotate(45),
+                            svglab.Translate(250, -300),
+                            svglab.SkewX(-45),
+                            svglab.SkewY(-20),
+                        ]
+                    )
+                ],
+            )
+        ),
     ],
 )
 def test_set_viewbox_produces_visually_equal_svg(svg: svglab.Svg) -> None:
@@ -866,7 +890,9 @@ def test_composed_decompose_equals_compose(
         [svglab.Rotate(50)],
         [svglab.SkewX(-10)],
         [svglab.SkewY(15)],
+        [svglab.Scale(0, 1)],
+        [svglab.Scale(0)],
     ],
 )
 def test_decompose_simple(transform: svglab.Transform) -> None:
-    assert list(svglab.compose(transform).decompose()) == transform
+    assert svglab.compose(transform).decompose() == transform

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -558,7 +558,7 @@ def test_matrix_multiplication(
     assert transformed == after
 
 
-_REIFY_TRANSFORMS: Final[list[svglab.Transform]] = [
+_TRANSFORMS: Final[list[svglab.Transform]] = [
     [svglab.Translate(10, 20)],
     [svglab.Translate(1, 5), svglab.Scale(0.5)],
     [svglab.Translate(2, 1)] * 10,
@@ -679,7 +679,7 @@ _REIFY_SVGS: Final[list[svglab.Svg]] = [
 ]
 
 
-@pytest.mark.parametrize("transform", _REIFY_TRANSFORMS)
+@pytest.mark.parametrize("transform", _TRANSFORMS)
 def test_reify_leaves_transform_empty(transform: svglab.Transform) -> None:
     svg = svglab.Svg(transform=transform)
     svg.reify()
@@ -687,7 +687,7 @@ def test_reify_leaves_transform_empty(transform: svglab.Transform) -> None:
     assert svg.transform is None
 
 
-@pytest.mark.parametrize("transform", _REIFY_TRANSFORMS)
+@pytest.mark.parametrize("transform", _TRANSFORMS)
 def test_reify_produces_visually_equal_svg_simple(
     transform: svglab.Transform,
 ) -> None:
@@ -819,3 +819,38 @@ def test_transform_swap(
 
     assert svglab.swap_transforms(a, b) == swapped
     assert svglab.swap_transforms(c, d) == original
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        *_TRANSFORMS,
+        [
+            svglab.Scale(2),
+            svglab.Translate(1, 2),
+            svglab.Rotate(15),
+            svglab.Rotate(30),
+            svglab.Translate(2, 4),
+            svglab.Rotate(10, 15, 30),
+        ],
+        [svglab.SkewX(45), svglab.SkewY(45)],
+        [svglab.Scale(0)],
+        [svglab.Rotate(45, 10, 10)],
+        [
+            svglab.Scale(1, 2),
+            svglab.Translate(1, 2),
+            svglab.Scale(2, 1),
+            svglab.Rotate(10),
+            svglab.Scale(0.5),
+        ],
+        [svglab.SkewX(30)],
+        [svglab.SkewY(30)],
+    ],
+)
+def test_decompose(transform: svglab.Transform) -> None:
+    matrix = svglab.compose(transform)
+    decomposed = matrix.decompose()
+
+    assert svglab.compose(decomposed) == matrix, (
+        f"{list(decomposed)=}, {matrix=}"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -847,10 +847,26 @@ def test_transform_swap(
         [svglab.SkewY(30)],
     ],
 )
-def test_decompose(transform: svglab.Transform) -> None:
+def test_composed_decompose_equals_compose(
+    transform: svglab.Transform,
+) -> None:
     matrix = svglab.compose(transform)
     decomposed = matrix.decompose()
 
     assert svglab.compose(decomposed) == matrix, (
         f"{list(decomposed)=}, {matrix=}"
     )
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        [svglab.Translate(1, 2)],
+        [svglab.Scale(2)],
+        [svglab.Rotate(50)],
+        [svglab.SkewX(-10)],
+        [svglab.SkewY(15)],
+    ],
+)
+def test_decompose_simple(transform: svglab.Transform) -> None:
+    assert list(svglab.compose(transform).decompose()) == transform


### PR DESCRIPTION
This PR adds support for processing general `matrix()` transformations inside `reify()`. This is done by decomposing the affine transformation matrices into sequences of elementary transformations. The decomposition algorithm is based on Frédéric Wang's [Decomposition of 2D-transform matrices](https://frederic-wang.fr/2013/12/01/decomposition-of-2d-transform-matrices/).

- adds `Matrix.decompose()`
- adds `decompose_matrices(transform)`
