### PR TITLE
Extend float precision settings

### DIFF
--- a/svglab/__init__.py
+++ b/svglab/__init__.py
@@ -151,6 +151,8 @@ from svglab.errors import (
 from svglab.parse import parse_svg
 from svglab.serialize import (
     DEFAULT_FORMATTER,
+    MINIMAL_FORMATTER,
+    FloatPrecisionSettings,
     Formatter,
     get_current_formatter,
     set_formatter,
@@ -160,6 +162,7 @@ from svglab.utiltypes import LengthUnit
 
 __all__ = [
     "DEFAULT_FORMATTER",
+    "MINIMAL_FORMATTER",
     "A",
     "AltGlyph",
     "AltGlyphDef",
@@ -214,6 +217,7 @@ __all__ = [
     "FeTurbulence",
     "Filter",
     "FilterPrimitiveElement",
+    "FloatPrecisionSettings",
     "Font",
     "FontFace",
     "FontFaceFormat",

--- a/svglab/__main__.py
+++ b/svglab/__main__.py
@@ -24,7 +24,7 @@ from svglab import (
 )
 
 
-set_formatter(Formatter(indent=4, max_precision=2, color_mode="rgb"))
+set_formatter(Formatter(indent=4, general_precision=2, color_mode="rgb"))
 
 
 def main() -> None:

--- a/svglab/attrparse/angle.py
+++ b/svglab/attrparse/angle.py
@@ -74,7 +74,7 @@ class Angle(
 
     @override
     def serialize(self) -> str:
-        value = serialize.serialize(self.value)
+        value = serialize.serialize(self.value, precision_group="angle")
         return f"{value}{self.unit or ''}"
 
     @override

--- a/svglab/attrparse/length.py
+++ b/svglab/attrparse/length.py
@@ -104,9 +104,11 @@ class Length(
                 converted = self.to(unit)
                 break
 
-        return (
-            f"{serialize.serialize(converted.value)}{converted.unit or ''}"
+        value = serialize.serialize(
+            converted.value, precision_group="coordinate"
         )
+
+        return f"{value}{converted.unit or ''}"
 
     @classmethod
     def zero(cls) -> Length:

--- a/svglab/attrparse/point.py
+++ b/svglab/attrparse/point.py
@@ -63,7 +63,9 @@ class _Point(
 
     @override
     def serialize(self) -> str:
-        x, y = serialize.serialize(self.x, self.y)
+        x, y = serialize.serialize(
+            self.x, self.y, precision_group="coordinate"
+        )
         formatter = serialize.get_current_formatter()
 
         return f"{x}{formatter.point_separator}{y}"

--- a/svglab/attrparse/transform.py
+++ b/svglab/attrparse/transform.py
@@ -133,7 +133,9 @@ class _Scale(_TransformFunctionBase):
         if not utils.is_close(self.sx, self.sy):
             args.append(self.sy)
 
-        return serialize.serialize_function_call("scale", *args)
+        return serialize.serialize_function_call(
+            "scale", *args, precision_group="scale"
+        )
 
     @override
     def to_affine(self) -> affine.Affine:
@@ -168,14 +170,15 @@ class _Rotate(_TransformFunctionBase):
 
     @override
     def serialize(self) -> str:
-        args = [self.angle]
+        angle = serialize.serialize(self.angle, precision_group="angle")
+        origin = []
 
         if not utils.is_close(self.cx, 0) or not utils.is_close(
             self.cy, 0
         ):
-            args.extend([self.cx, self.cy])
+            origin.extend([self.cx, self.cy])
 
-        return serialize.serialize_function_call("rotate", *args)
+        return serialize.serialize_function_call("rotate", angle, *origin)
 
     @override
     def to_affine(self) -> affine.Affine:
@@ -215,7 +218,9 @@ class SkewY(_TransformFunctionBase):
 
     @override
     def serialize(self) -> str:
-        return serialize.serialize_function_call("skewY", self.angle)
+        return serialize.serialize_function_call(
+            "skewY", self.angle, precision_group="angle"
+        )
 
     @override
     def to_affine(self) -> affine.Affine:
@@ -235,7 +240,9 @@ class SkewX(_TransformFunctionBase):
 
     @override
     def serialize(self) -> str:
-        return serialize.serialize_function_call("skewX", self.angle)
+        return serialize.serialize_function_call(
+            "skewX", self.angle, precision_group="angle"
+        )
 
     @override
     def to_affine(self) -> affine.Affine:

--- a/svglab/attrs/names.py
+++ b/svglab/attrs/names.py
@@ -331,14 +331,14 @@ def _normalize_attr_name(name: AttributeName) -> str:
     return normalized
 
 
-_ATTRIBUTE_NAMES: Final[frozenset[AttributeName]] = frozenset(
+ATTRIBUTE_NAMES: Final[frozenset[AttributeName]] = frozenset(
     typing_extensions.get_args(AttributeName)
 )
 """A set of all valid SVG attribute names."""
 
 
 ATTR_NAME_TO_NORMALIZED: Final = bidict.frozenbidict(
-    {attr: _normalize_attr_name(attr) for attr in _ATTRIBUTE_NAMES}
+    {attr: _normalize_attr_name(attr) for attr in ATTRIBUTE_NAMES}
 )
 """
 A bidirectional mapping of SVG attribute names to normalized

--- a/svglab/elements/common.py
+++ b/svglab/elements/common.py
@@ -703,7 +703,7 @@ class Tag(
         tag.can_be_empty_element = len(self.__children) == 0
 
         for key, value in self.all_attrs().items():
-            tag[key] = serialize.serialize_attr(value)
+            tag[key] = serialize.serialize_attr(key, value)
 
         for child in self.children:
             tag.append(child.to_beautifulsoup_object())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -902,3 +902,44 @@ def test_decompose_simple(transform: svglab.Transform) -> None:
 
 def test_entity_substitution() -> None:
     assert svglab.RawText(">").to_xml() == "&gt;"
+
+
+def test_float_precision_settings() -> None:
+    formatter = svglab.Formatter(
+        general_precision=10,
+        angle_precision=1,
+        coordinate_precision=0,
+        scale_precision=-1,
+    )
+
+    with formatter:
+        assert svglab.Length(1.123456).serialize() == "1"
+        assert svglab.Rotate(1.123456).serialize() == "rotate(1.1)"
+        assert svglab.SkewX(1.123456).serialize() == "skewX(1.1)"
+        assert (
+            svglab.Translate(1.123456).serialize() == "translate(1.123456)"
+        )
+        assert svglab.Scale(1.123456).serialize() == "scale(0)"
+
+
+def test_precision_table() -> None:
+    formatter = svglab.Formatter(
+        general_precision=svglab.FloatPrecisionSettings(
+            precision_table={
+                (0, 1): 3,
+                (1, 10): 2,
+                (10, 100): 1,
+                (100, 1000): 0,
+            },
+            fallback=15,
+        )
+    )
+
+    with formatter:
+        assert svglab.Length(0.123456).serialize() == ".123"
+        assert svglab.Rotate(1.123456).serialize() == "rotate(1.12)"
+        assert svglab.SkewX(10.123456).serialize() == "skewX(10.1)"
+        assert svglab.Translate(100.123456).serialize() == "translate(100)"
+        assert (
+            svglab.Scale(1000.123456).serialize() == "scale(1000.123456)"
+        )


### PR DESCRIPTION
Adds more control over floating-point precision to the `Formatter`. The `Formatter` now contains the following settings:

- `coordinate_precision` - for `Length` and `Point`,
- `opacity_precision` - for `opacity-*` attributes,
- `angle_precision` - for `Angle` and angles in `Rotate` and `SkewX`, `SkewY`,
- `scale_precision` - for `Scale`,
- `general_precision` - for everything else; also acts as a fallback for the other groups if they are not set (which is the default).

These attributes can either be set to an `int`, in which case the value specifies how many digits of precision to use when serializing numbers in said category. If more control is needed, it is possible to create and assign a `FloatPrecisionSettings` instance, which has the following two attributes:

- `precision_table` - defines a table of intervals and their associated precision; for instance
  ```python
  precision_table = {(0, 1): 2, (1, 10): 3}
  ```
  specifies that numbers in the range $[0, 1)$ should be serialized using 2 digits of precision, and numbers in the range $[1, 10)$ will use 3 digits.

- `fallback` - defines the fallback precision for numbers that do not fall into any of the intervals defined by `precision_table`

